### PR TITLE
allow php version to be changed via ENV

### DIFF
--- a/.deploy/Dockerfile
+++ b/.deploy/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=${PHP_VERSION:-7.4}
 FROM php:${PHP_VERSION}-fpm-alpine AS php-system-setup
 
 # Install system dependencies

--- a/.deploy/entrypoint.sh
+++ b/.deploy/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-echo "🎬 entrypoint.sh: [$(whoami)]"
+echo "🎬 entrypoint.sh: [$(whoami)] [PHP $(php -r 'echo phpversion();')]"
 
 composer dump-autoload --no-interaction --no-dev --optimize
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
 
 ## Features
 
-- 🐳 Lightweight [PHP 7.4](https://github.com/jackbrycesmith/laravel-caprover-template/blob/master/.deploy/Dockerfile#L1) image with [common extensions](https://github.com/jackbrycesmith/laravel-caprover-template/blob/master/.deploy/Dockerfile#L21); add/remove as required
+- 🐳 Lightweight [PHP](https://github.com/jackbrycesmith/laravel-caprover-template/blob/master/.deploy/Dockerfile#L1) image with [common extensions](https://github.com/jackbrycesmith/laravel-caprover-template/blob/master/.deploy/Dockerfile#L21)
+  - [Overridable PHP version](https://github.com/jackbrycesmith/laravel-caprover-template/pull/13)
+  - Add other required extensions easily; [thanks to mlocati/docker-php-extension-installer](https://github.com/mlocati/docker-php-extension-installer)
 - 📦 [Installs composer dependencies](https://github.com/jackbrycesmith/laravel-caprover-template/blob/master/.deploy/Dockerfile#L30); cached between builds if no changes
 - ⚡️ Served via [Caddy 2](https://github.com/caddyserver/caddy)
 - ⏰ [Setup to call](https://github.com/jackbrycesmith/laravel-caprover-template/blob/master/.deploy/Dockerfile#L11) the [Laravel command scheduler](https://laravel.com/docs/7.x/scheduling)


### PR DESCRIPTION
This allows you to override the default php version by setting a `PHP_VERSION` environment variable (e.g. `PHP_VERSION=7.4.13`) in the CapRover dashboard. Two things to bear in mind...

1. Ensure the PHP_VERSION has been [tagged in the official docker images](https://hub.docker.com/_/php?tab=tags&page=1&ordering=last_updated&name=fpm-alpine)
2. Ensure any extensions are available: https://github.com/mlocati/docker-php-extension-installer